### PR TITLE
chore: Update Clickhouse server version to 24.8

### DIFF
--- a/docker/docker-compose-restricted.yml
+++ b/docker/docker-compose-restricted.yml
@@ -353,7 +353,7 @@ services:
       - minio_data:/data
 
   clickhouse:
-    image: clickhouse/clickhouse-server:23.8
+    image: clickhouse/clickhouse-server:24.8
     networks:
       - internal_net
     security_opt:

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -223,7 +223,7 @@ services:
       - minio_data:/data
 
   clickhouse:
-    image: clickhouse/clickhouse-server:23.8
+    image: clickhouse/clickhouse-server:24.8
     ports:
       - "8123:8123" # http port
       - "9100:9000" # native port

--- a/kubernetes/helm-chart/values.yaml
+++ b/kubernetes/helm-chart/values.yaml
@@ -83,7 +83,7 @@ postgres:
 clickhouse:
   enabled: true
   image: clickhouse/clickhouse-server
-  version: "23.8"
+  version: "24.8"
   storage:
     size: 10Gi
     storageClass: "" # Use cluster default if not specified


### PR DESCRIPTION
Make sure that we make sure that the Clickhouse version is set to 24.8 (the same version as the `benchmark` directory).