### PR TITLE
chore: Update image repository URLs in .env.example

### DIFF
--- a/docker/.env.example
+++ b/docker/.env.example
@@ -1,8 +1,8 @@
 GENTRACE_CORE_VERSION=production
 
 # Image repository prefix URLs for environments with mandated proxy URLs
-# QUAY_IMAGE_URL_PREFIX="quay.io"
-# DOCKER_REGISTRY_URL_PREFIX=""
+QUAY_IMAGE_URL_PREFIX="quay.io"
+DOCKER_REGISTRY_URL_PREFIX=""
 
 # Database
 DATABASE_URL=postgresql://gentrace:gentrace123@postgres:5432/gentrace


### PR DESCRIPTION
### Background

Modfy the example environmental variables file to explicitly include the URL prefixes, so it doesn't throw any warnings when you bring up the Docker containers. 