### PR TITLE
chore: Remove commented note about websocket-server routing configuration

### DIFF
--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -70,8 +70,6 @@ services:
       minio-init:
         condition: service_completed_successfully
 
-  # Note: Routing to websocket-server is not yet configured from the app container. This
-  # service will not be accessible externally.
   websocket-server:
     platform: linux/amd64
     image: ${QUAY_IMAGE_URL_PREFIX:-quay.io}/gentrace/core:${GENTRACE_CORE_VERSION:-production}


### PR DESCRIPTION
## TLDR
Removes outdated comment about websocket-server routing configuration in docker-compose.yml

## Summary
This PR cleans up the docker-compose configuration by removing a comment that is no longer accurate. The comment previously indicated that websocket-server routing wasn't configured, but this functionality is now handled through the `WEBSOCKET_URL` environment variable.

## Key Changes
- Removed 2-line comment above the `websocket-server` service definition in docker-compose.yml
- No functional changes to the actual service configuration

## Impact
- Docker configuration files only
- No impact on runtime behavior or functionality

## Testing Considerations
- Verify that websocket-server continues to function correctly with existing `WEBSOCKET_URL` configuration
- Ensure docker-compose services start up without issues