### PR TITLE
feat: Add script to convert private key to env var format

### DIFF
--- a/docker/scripts/convert-private-key-to-env.sh
+++ b/docker/scripts/convert-private-key-to-env.sh
@@ -1,0 +1,34 @@
+#!/bin/bash
+
+# Script to convert a private key to single line format for llm-auth.ts environment variables
+# Purpose: Formats RSA private keys for use with app/src/server/apiStandards/llm-auth.ts
+# Usage: ./convert-private-key-to-env.sh <private_key_file>
+
+if [ $# -eq 0 ]; then
+    echo "Usage: $0 <private_key_file>"
+    echo "Example: $0 private_key.pem"
+    echo ""
+    echo "This script formats RSA private keys for use with llm-auth.ts"
+    echo "The output can be used for the LLM_AUTH_PK_VALUE environment variable"
+    exit 1
+fi
+
+KEY_FILE="$1"
+
+if [ ! -f "$KEY_FILE" ]; then
+    echo "Error: File '$KEY_FILE' not found"
+    exit 1
+fi
+
+# Read the file and convert newlines to literal \n
+# This preserves the PEM format structure when stored as a single line
+ONE_LINE_KEY=$(awk 'NF {sub(/\r/, ""); printf "%s\\n",$0;}' "$KEY_FILE" | sed 's/\\n$//')
+
+# Output the result
+echo "# Add this to your .env file or export it for llm-auth.ts:"
+echo "LLM_AUTH_PK_VALUE=\"$ONE_LINE_KEY\""
+
+# Optionally, also show just the raw value for copying
+echo ""
+echo "# Or just the value:"
+echo "$ONE_LINE_KEY" 


### PR DESCRIPTION
## PR Description

### TLDR
Adds utility script to convert RSA private keys to single-line format for environment variables

### Summary
This PR introduces a bash script that converts multi-line RSA private key files into a single-line format suitable for use as environment variables, specifically for the `LLM_AUTH_PK_VALUE` variable used by the llm-auth.ts authentication system.

### Key Changes
- Added `convert-private-key-to-env.sh` script in `docker/scripts/`
- Script converts PEM-formatted private keys by replacing newlines with literal `\n`
- Provides formatted output ready for `.env` files or direct export
- Includes usage instructions and error handling

### Impact
- Affects deployment and configuration workflows
- Simplifies setup for llm-auth.ts authentication
- No changes to existing application code

### Testing Considerations
- Test with various RSA private key formats (PKCS#1, PKCS#8)
- Verify the converted key works correctly with llm-auth.ts
- Test error handling for missing or invalid files
- Ensure the script preserves the exact PEM structure when converted