### PR TITLE
feat: Add scripts to collect and extract docker logs

### DIFF
--- a/docker/collect-logs.sh
+++ b/docker/collect-logs.sh
@@ -1,0 +1,40 @@
+#!/bin/bash
+
+# Script to collect docker compose logs and create a tar.gz archive
+# Uses only standard Debian utilities
+
+# Set script options
+set -e  # Exit on error
+
+# Variables
+TIMESTAMP=$(date +"%Y%m%d_%H%M%S")
+LOG_DIR="docker_logs_${TIMESTAMP}"
+ARCHIVE_FILE="docker_logs_${TIMESTAMP}.tar.gz"
+
+# Create temporary directory for logs
+echo "Creating temporary directory for logs..."
+mkdir -p "${LOG_DIR}"
+
+# Get list of all running containers
+echo "Collecting logs from docker compose services..."
+docker compose ps --services | while read -r service; do
+    if [ -n "$service" ]; then
+        echo "  - Collecting logs for service: $service"
+        docker compose logs "$service" > "${LOG_DIR}/${service}.log" 2>&1 || true
+    fi
+done
+
+# Also save docker compose ps output for reference
+echo "Saving docker compose status..."
+docker compose ps > "${LOG_DIR}/docker_compose_ps.txt" 2>&1
+
+# Create tar.gz archive
+echo "Creating tar.gz archive: ${ARCHIVE_FILE}"
+tar -czf "${ARCHIVE_FILE}" "${LOG_DIR}"
+
+# Clean up temporary directory
+echo "Cleaning up temporary files..."
+rm -rf "${LOG_DIR}"
+
+echo "Done! Logs have been saved to: ${ARCHIVE_FILE}"
+echo "File size: $(du -h "${ARCHIVE_FILE}" | cut -f1)"

--- a/docker/extract-logs.sh
+++ b/docker/extract-logs.sh
@@ -1,0 +1,46 @@
+#!/bin/bash
+
+# Script to extract docker compose logs from tar.gz archive
+# Uses only standard Debian utilities
+
+# Set script options
+set -e  # Exit on error
+
+# Check if argument is provided
+if [ $# -eq 0 ]; then
+    echo "Usage: $0 <log_archive.tar.gz>"
+    echo "Example: $0 docker_logs_20240102_143022.tar.gz"
+    exit 1
+fi
+
+ARCHIVE_FILE="$1"
+
+# Check if file exists
+if [ ! -f "$ARCHIVE_FILE" ]; then
+    echo "Error: File '$ARCHIVE_FILE' not found!"
+    exit 1
+fi
+
+# Check if file has correct extension
+if [[ ! "$ARCHIVE_FILE" =~ \.tar\.gz$ ]]; then
+    echo "Error: File must be a .tar.gz archive!"
+    exit 1
+fi
+
+# Extract archive
+echo "Extracting logs from: $ARCHIVE_FILE"
+tar -xzf "$ARCHIVE_FILE"
+
+# Get the directory name (tar will create it)
+EXTRACTED_DIR=$(tar -tzf "$ARCHIVE_FILE" | head -1 | cut -d'/' -f1)
+
+echo "Logs extracted to directory: $EXTRACTED_DIR"
+echo ""
+echo "Contents:"
+ls -la "$EXTRACTED_DIR"
+echo ""
+echo "To view a specific log:"
+echo "  cat $EXTRACTED_DIR/<service_name>.log"
+echo ""
+echo "To view all logs:"
+echo "  less $EXTRACTED_DIR/*.log"


### PR DESCRIPTION
## TLDR
Adds utility scripts to collect and extract Docker Compose logs into compressed archives

## Summary
This PR introduces two bash scripts that simplify the process of collecting logs from Docker Compose services. The scripts create timestamped archives of all container logs, making it easier to share and analyze logs for debugging purposes.

## Key Changes
- Added `collect-logs.sh` to gather logs from all Docker Compose services into a timestamped tar.gz archive
- Added `extract-logs.sh` to extract and view logs from previously created archives
- Scripts use only standard Debian utilities for maximum compatibility
- Includes Docker Compose service status information alongside logs

## Impact
- **Docker tooling**: New utility scripts in the `/docker` directory
- **Operations**: Simplifies log collection and sharing for debugging
- **No code changes**: Only adds standalone bash scripts

## Testing Considerations
- Verify scripts work with active Docker Compose environments
- Test with services that have no logs or are not running
- Confirm tar.gz archives are created and extracted correctly
- Check script behavior when Docker Compose is not available