### PR TITLE
Fix ClickHouse table name in ingestion tests

### DIFF
--- a/docker/ingestion-tests/python/test_ingestion_pipeline.py
+++ b/docker/ingestion-tests/python/test_ingestion_pipeline.py
@@ -322,7 +322,7 @@ class IngestionTester:
         return success
     
     def validate_clickhouse_replication(self, trace_ids: List[str], max_wait: int = 120) -> bool:
-        """Validate that data was replicated to ClickHouse GTSpan table."""
+        """Validate that data was replicated to ClickHouse span table."""
         print("🔍 Validating ClickHouse replication...")
         print("   Note: ClickHouse replication is eventually consistent, allowing extra time...")
         
@@ -347,7 +347,7 @@ class IngestionTester:
                         attributesMap,
                         traceId,
                         pipelineId
-                    FROM GTSpan 
+                    FROM span 
                     WHERE pipelineId = '{self.config.pipeline_id}'
                     ORDER BY createdAt DESC
                     LIMIT 50

--- a/docker/ingestion-tests/typescript/test-ingestion-node.ts
+++ b/docker/ingestion-tests/typescript/test-ingestion-node.ts
@@ -457,7 +457,7 @@ class NodeIngestionTester {
                         attributesMap,
                         traceId,
                         pipelineId
-                    FROM GTSpan 
+                    FROM span 
                     WHERE pipelineId = '${config.pipelineId}'
                     ORDER BY createdAt DESC
                     LIMIT 50


### PR DESCRIPTION
## Summary
- Fixed failing ingestion tests by updating ClickHouse table name from `GTSpan` to `span`
- The tests were looking for the wrong table name in ClickHouse, causing the Docker Compose test workflow to fail

## Details
The ingestion tests (both Python and TypeScript versions) were querying a table named `GTSpan` in ClickHouse, but the actual table is named `span`. This was evident from the cleanup section of the workflow which correctly queries the `span` table:

```bash
curl -s "http://localhost:8123/?query=SELECT id, name, createdAt FROM span ORDER BY createdAt DESC LIMIT 5 FORMAT JSON"
```

## Test plan
- [x] Updated Python test to query correct table name
- [x] Updated TypeScript test to query correct table name
- [ ] Tests should now pass in the CI workflow

🤖 Generated with [Claude Code](https://claude.ai/code)